### PR TITLE
added fingerprint haval jolion hev

### DIFF
--- a/opendbc/car/gwm/fingerprints.py
+++ b/opendbc/car/gwm/fingerprints.py
@@ -10,4 +10,9 @@ FW_VERSIONS = {
       b'\xf1\x873612100XEC56000\xf1\x89S013A01XKN17002',
     ],
   },
+  CAR.GWM_HAVAL_JOLION_HEV: {
+    (Ecu.engine, 0x7e0, None): [
+      b'\xf1\x873612100XEG01H00\xf1\x89S013A01XST17008',
+    ],
+  }
 }

--- a/opendbc/car/gwm/values.py
+++ b/opendbc/car/gwm/values.py
@@ -43,6 +43,10 @@ class CAR(Platforms):
     [GWMCarDocs("Haval H6 2019-26")],
     CarSpecs(mass=2040, wheelbase=2.738, steerRatio=17.416),
   )
+  GWM_HAVAL_JOLION_HEV = GWMPlatformConfig(
+    [GWMCarDocs("Haval Jolion HEV 2026-01")],
+    CarSpecs(mass=1940, wheelbase=2.700, steerRatio=17.416),
+  )
 
 
 GREATWALLMOTORS_VERSION_REQUEST_MULTI = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER]) + \


### PR DESCRIPTION
Added fingerprint for haval jolion HEV 2016

driving route:
https://connect.comma.ai/43c6c755ff0b0948/00000003--9385d3942d

